### PR TITLE
Transaction observer was disabled in mainnet-bitcoin-docker-config.json

### DIFF
--- a/docker/deploy-docker-mainnet.sh
+++ b/docker/deploy-docker-mainnet.sh
@@ -86,6 +86,7 @@ echo "
   \"port\": 3002,
   \"sidetreeTransactionFeeMarkupPercentage\": 1,
   \"sidetreeTransactionPrefix\": \"ion:\",
+  \"transactionPollPeriodInSeconds\": 60,
   \"valueTimeLockAmountInBitcoins\": 0
 }" > ../json/mainnet-bitcoin-docker-config.json
 


### PR DESCRIPTION
ion-bitcoin-mainnet fails to start properly with transaction observer disabled