### PR TITLE
Fixes decentralized-identity/ion#179

### DIFF
--- a/ion/js/explorer.js
+++ b/ion/js/explorer.js
@@ -339,8 +339,9 @@ async function searchForDID(){
   try {
     result = await fetch('https://beta.discover.did.microsoft.com/1.0/identifiers/' + didURI).then(async response => {
       search.setAttribute('status', response.status);
-      if (response.status >= 400) throw '';
       currentDidSearch = didURI;
+
+      if (response.status >= 400) throw '';
       return response.json();
     });
   }


### PR DESCRIPTION
currentDidSearch was not updated if server returned http >400. Updating the variable before checking status code of the response seems to work. @csuwildcat

Repro steps from issue:
1. search for: did:ion:EiClkZMDxPKqC9c-umQfTkR8vvZ9JPhl_xLDI9Nfk38w5w => http 200 **currentDidSearch set**
2. search for: did:ion:EiClkZMDxPKqC9c-umQfTkR8vvZ9JPhl_xLDI9Nfk38w5 => http 404 **currentDidSearch not set**, still contains the old value after failed search
3. search for: did:ion:EiClkZMDxPKqC9c-umQfTkR8vvZ9JPhl_xLDI9Nfk38w5w => **does not work**, currentDidSearch matches value from the previous search
