### PR TITLE
Set DID Resolution Result media type

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -69,7 +69,17 @@ router.get(`${resolvePath}:did`, async (ctx, _next) => {
   // Strip away the first '/identifiers/' string.
   const didOrDidDocument = ctx.url.split(resolvePath)[1];
   const response = await sidetreeCore.handleResolveRequest(didOrDidDocument);
-  setKoaResponse(response, ctx.response);
+  const koaResponse = ctx.response;
+  koaResponse.status = SidetreeResponse.toHttpStatus(response.status);
+
+  if (!response.body) {
+    koaResponse.body = '';
+  } else {
+    koaResponse.set('Content-Type', 'application/ld+json;profile="https://w3id.org/did-resolution";charset=utf-8');
+    // Stringify the result as otherwise the Content-Type gets overridden to
+    // application/json.
+    koaResponse.body = JSON.stringify(response.body);
+  }
 });
 
 router.get('/monitor/operation-queue-size', async (ctx, _next) => {


### PR DESCRIPTION
Set the Content-Type header of the DID Resolution Result HTTP response to use the media type with [profile](https://www.w3.org/TR/json-ld11/#application-ld-json) parameter specified for a DID Resolution Result in [DID Resolution](https://w3c-ccg.github.io/did-resolution/#did-resolution-result): `application/ld+json;profile="https://w3id.org/did-resolution"`.

Setting this Content-Type header helps DID resolver HTTP clients detect that the response is a DID Resolution Result - rather than e.g. a DID document alone, which is also allowed by [DID Resolution's HTTP(S) Binding](https://w3c-ccg.github.io/did-resolution/#bindings-https).