### PR TITLE
Fixed typo in design.md: "formulae"

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -8,7 +8,7 @@
 
 If you want to write transactions containing more than 100 operations, you are required to lock some BTC for exactly 4500 blocks using a time locked transaction.
 
-The formulae to calculate the required lock amount can be calculated using:
+The formula to calculate the required lock amount can be calculated using:
 
 ```
 requiredLockedBtc = numberOfOpsPerTransactionDesired x estimatedNormalizedFee x normalizedFeeToPerOperationFeeMultiplier x valueTimeLockAmountMultiplier

--- a/ion/index.html
+++ b/ion/index.html
@@ -27,6 +27,7 @@
 </head>
 
   <body>
+    <h1> Hola </h1>
 
     <svg style="display: none">
       

--- a/ion/index.html
+++ b/ion/index.html
@@ -27,7 +27,6 @@
 </head>
 
   <body>
-    <h1> Hola </h1>
 
     <svg style="display: none">
       


### PR DESCRIPTION
Found a typo reading the design.md file. 
Changed "formulae" to "formula"