### PR TITLE
Add Max Long-Form DID Length to Docs

### DIFF
--- a/docs/Q-and-A.md
+++ b/docs/Q-and-A.md
@@ -332,7 +332,7 @@ _This is a giant leap forward for individuals and their privacy._ - (_@mkaplanPM
 ## *Q: Who owns the DIDs generated with ION?
 Ownership of your DIDs is based on keys you generate locally, and all ION operations are signed with those keys, so even if you use our node for anchoring DID operations (or any other node), you are always in sole control.\
 (_@csuwildcat_)
-## *Q: They probably already have my ID, why would i tokenize it?
+## *Q: They probably already have my ID, why would I tokenize it?
 It's not tokenizing your identity, it provides Identifiers you own and control - for example: if you had a DID linked to a personal datastore, people could follow your DID and fetch tweets from you, meaning Twitter can't erase your ID or censor your posts.
 ## **Q: Where can I see what data points someone can set up around their own DID? 
 _For example, name, address, driving licence. There must be a huge array of fields someone can include within their DID for it to be comprehensive?_\

--- a/docs/design.md
+++ b/docs/design.md
@@ -137,6 +137,8 @@ This means you will need to lock 0.66 BTC in order for transactions of 1000 oper
 
 - The delay in anchoring could be intentional or technical.
 
+- When generating Long-Form DIDs, it is recommended to keep the `<initial-state>` size to less than 1000 bytes to avoid max URL length issues.
+
 - Explained in detail in [Sidetree spec](https://identity.foundation/sidetree/spec/#long-form-did-uris).
 
 ### Late Publishing


### PR DESCRIPTION
Adding a note in the docs for recommending a max Long-Form DID length. Since Long-Form DIDs over ~1000 bytes can cause issues when placed in URL parameters of GET requests, it is best to keep the canonicalized delta to under 1000 bytes.

A canonicalized delta max size of 1000 bytes can be seen in the [default ion-sdk configuration](https://github.com/decentralized-identity/ion-sdk/blob/0af90f7944fa45a9151d782dd70455d9481ed71f/lib/IonSdkConfig.ts#L15), where it rejects deltas greater than 1000 bytes & throws an exception: 

<img width="1288" alt="image" src="https://user-images.githubusercontent.com/20134674/163635785-5d1354b5-8d48-4dfe-9f21-5a1c679b3754.png">
