### PR TITLE
update go image, works on ARM now as well

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,8 +23,7 @@ services:
       - ${DB_VOL}:/data/db
   ipfs:
     container_name: ipfs
-#this image doesn't work on ARM64 yet, use mhoekstra/go-ipfs:v0.7.0 if you want to deploy on ARM    
-    image: ipfs/go-ipfs
+    image: ipfs/go-ipfs:master-latest
     environment: 
       - IPFS_PATH=/data/ipfs
     volumes:


### PR DESCRIPTION
ipfs-go has a new docker image which also works on ARM  like raspberry pi